### PR TITLE
Revert output change of check operation

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -7,6 +7,6 @@ exec 1>&2 # redirect all output to stderr for logging
 
 PATH=/usr/local/bin:$PATH
 
-echo '{"version": {}}' >&3
+echo '[]' >&3
 
 exit 0


### PR DESCRIPTION
Currently on concourse 3.4.1 follow error is logged for the `check` operation. It happens even if the resource is only used as `put`:

    json: cannot unmarshal object into Go value of type []atc.Version

It seems for check the behaviour before f14f16d0038803cdb1790f3a341226db1941e91e was right. I reverted to the old format.

Thanks for the nice resource!